### PR TITLE
Add p1LoadRawCc module with tests and error enums

### DIFF
--- a/server/specificFunctions/p1StreamPmData/p1ProcessDevice/p1LoadRawCc/ErrorsEnum.js
+++ b/server/specificFunctions/p1StreamPmData/p1ProcessDevice/p1LoadRawCc/ErrorsEnum.js
@@ -1,0 +1,16 @@
+const ERRORS = {
+  PARAMETERS_NOT_PROVIDED: 'parameters not provided',
+  PARAMETERS_INVALID: 'parameters invalid',
+  MWDI_REPLICA_ES_CLIENT_NOT_PROVIDED: 'mwdiReplicaEsClient not provided',
+  MWDI_REPLICA_ES_CLIENT_INVALID: 'mwdiReplicaEsClient invalid',
+  DATA_STORE_ES_CLIENT_NOT_PROVIDED: 'dataStoreEsClient not provided',
+  DATA_STORE_ES_CLIENT_INVALID: 'dataStoreEsClient invalid',
+  MOUNT_NAME_NOT_PROVIDED: 'mountName not provided',
+  MOUNT_NAME_INVALID: 'mountName invalid',
+  RAW_CC_COULD_NOT_BE_PROVIDED: 'rawCc could not be provided',
+  GENERAL_PROCESSING_ERROR: 'General processing error'
+};
+
+ERRORS.knownErrors = new Set(Object.values(ERRORS));
+
+module.exports = ERRORS;

--- a/server/specificFunctions/p1StreamPmData/p1ProcessDevice/p1LoadRawCc/P1LoadRawCc.js
+++ b/server/specificFunctions/p1StreamPmData/p1ProcessDevice/p1LoadRawCc/P1LoadRawCc.js
@@ -4,6 +4,7 @@ const { withRetry } = require("../../../../utils/retry");
 const p1FieldsFilter = require("./../../../../genericFunctions/p1FieldsFilter/P1FieldsFilter");
 const p1DiscardIrrelevantPmRecords = require("./../../../../genericFunctions/p1DiscardIrrelevantPmRecords/P1DiscardIrrelevantPmRecords");
 const logger = require('../../../../service/LoggingService.js').getLogger();
+const ERRORS = require('./ErrorsEnum.js');
 
 const AIR_INTERFACE_PAC_KEY = "air-interface-2-0:air-interface-pac";
 const ETHERNET_CONTAINER_PAC_KEY = "ethernet-container-2-0:ethernet-container-pac";
@@ -131,17 +132,17 @@ async function loadInterfaceMetadataList(
       logger
     }
   ).catch((error) => {
-      /* logger.error(
-        {
-          label: "load-interface-metadata-list",
-          error: error.message || error
-        },
-        "Failed to load interface metadata list"
-      ); */
-      //if (error.meta && error.meta.statusCode === 404) {
-        return [];
-      //}
-    });
+    logger.error(
+      {
+        label: "load-interface-metadata-list",
+        mountName,
+        error: error.message || error
+      },
+      "Failed to load interface metadata list from data store"
+    );
+    //return [];
+    throw new Error("interfaceMetadataList could not be provided");
+  });
 
   const source = (response || {}).body?._source || {};
   return source["interface-metadata-list"] || [];
@@ -177,7 +178,7 @@ async function filterHistoricalList(
 
   const discardInput = {
     ...list,
-    "relevant-granularities":relevantGranularities,
+    "relevant-granularities": relevantGranularities,
     "most-recent-period-end-time": mostRecentPeriodEndTime,//(mostRecentPeriodEndTime != undefined) ? new Date(mostRecentPeriodEndTime) : mostRecentPeriodEndTime,
     "most-recent-period-end-time-24": mostRecentPeriodEndTime24,//(mostRecentPeriodEndTime24 != undefined) ? new Date(mostRecentPeriodEndTime24) : mostRecentPeriodEndTime24
   };
@@ -186,9 +187,13 @@ async function filterHistoricalList(
   if (isValidDiscardResponse(response)) {
     return response["filtered-historical-performance-data-list"];
   }
-  
+
   const inputSummary = {
-    inputRecordCount: list.length,
+    inputRecordCount:
+      Array.isArray(list["historical-performance-data-list"])
+        ? list["historical-performance-data-list"].length
+        : 0,
+    //list.length,
     relevantGranularities,
     mostRecentPeriodEndTime: discardInput["most-recent-period-end-time"],
     mostRecentPeriodEndTime24: discardInput["most-recent-period-end-time-24"]
@@ -205,7 +210,8 @@ async function filterHistoricalList(
     );
   }
 
-  throw buildDiscardPmError(response, inputSummary);
+  //throw buildDiscardPmError(response, inputSummary);
+  throw new Error(ERRORS.GENERAL_PROCESSING_ERROR);
 }
 
 const DEFAULT_BATCH_TIMESTAMP = "2010-11-20T14:00:00+01:00";
@@ -354,42 +360,82 @@ async function run(request) {
     mwdiReplicaEsClient,
     dataStoreEsClient,
     mountName,
-    //logger
-  } = request;
+  } = request || {};
 
   try {
-    const replicaClient = await onfAdapter.getEsClient(
-      false,
-      mwdiReplicaEsClient.uuid,
-      mwdiReplicaEsClient,
-      logger
-    );
+    // --- Input validation ---
+    if (parameters === undefined || parameters === null) {
+      throw new Error(ERRORS.PARAMETERS_NOT_PROVIDED);
+    }
+    if (!isPlainObject(parameters)) {
+      throw new Error(ERRORS.PARAMETERS_INVALID);
+    }
 
-    const rawResponse = await withRetry(
-      async () =>
-        replicaClient.get({
-          index: mwdiReplicaEsClient["index-alias"],
-          id: mountName
-      }),
-      {
-        label: `loadRawCc:${mountName}`,
-        retryIntervalMs: 10000,
+    if (mwdiReplicaEsClient === undefined || mwdiReplicaEsClient === null) {
+      throw new Error(ERRORS.MWDI_REPLICA_ES_CLIENT_NOT_PROVIDED);
+    }
+    if (!isPlainObject(mwdiReplicaEsClient) || !mwdiReplicaEsClient.uuid || !mwdiReplicaEsClient["index-alias"]) {
+      throw new Error(ERRORS.MWDI_REPLICA_ES_CLIENT_INVALID);
+    }
+
+    if (dataStoreEsClient === undefined || dataStoreEsClient === null) {
+      throw new Error(ERRORS.DATA_STORE_ES_CLIENT_NOT_PROVIDED);
+    }
+    if (!isPlainObject(dataStoreEsClient) || !dataStoreEsClient.uuid || !dataStoreEsClient["index-alias"]) {
+      throw new Error(ERRORS.DATA_STORE_ES_CLIENT_INVALID);
+    }
+
+    if (mountName === undefined || mountName === null) {
+      throw new Error(ERRORS.MOUNT_NAME_NOT_PROVIDED);
+    }
+    if (typeof mountName !== "string" || mountName.trim() === "") {
+      throw new Error(ERRORS.MOUNT_NAME_INVALID);
+    }
+
+    // --- Read ControlConstruct from Replica ES ---
+    let replicaClient;
+    try {
+      replicaClient = await onfAdapter.getEsClient(
+        false,
+        mwdiReplicaEsClient.uuid,
+        mwdiReplicaEsClient,
         logger
-      }
-    ).catch((error) => {
-      /* logger.error(
+      );
+    } catch (error) {
+      logger.error(
+        { label: "p1LoadRawCc:getReplicaClient", error: error.message || error },
+        "Failed to initialize MWDI replica ES client"
+      );
+      throw new Error(ERRORS.MWDI_REPLICA_ES_CLIENT_INVALID);
+    }
+
+    let rawResponse;
+    try {
+      rawResponse = await withRetry(
+        async () =>
+          replicaClient.get({
+            index: mwdiReplicaEsClient["index-alias"],
+            id: mountName
+          }),
         {
-          label: "load-raw-cc",
-          error: error.message || error
-        },
-        "Failed to load raw CC from replica"
-      ); */
-    });
+          label: `loadRawCc:${mountName}`,
+          retryIntervalMs: 10000,
+          logger
+        }
+      );
+    } catch (error) {
+      logger.error(
+        { label: "p1LoadRawCc:readControlConstruct", mountName, error: error.message || error },
+        "Failed to read ControlConstruct from replica ES"
+      );
+      throw new Error(ERRORS.RAW_CC_COULD_NOT_BE_PROVIDED);
+    }
 
     let rawCc = (rawResponse || {}).body?._source["core-model-1-4:control-construct"] || {
       mountName
     };
 
+    // --- Apply fields filter ---
     const fieldsFilterString = getParamFromFunction(
       parameters,
       "p1FieldsFilter",
@@ -397,25 +443,53 @@ async function run(request) {
       ""
     );
 
-    const fieldsFilterResponse = await p1FieldsFilter.run({
+    let fieldsFilterResponse;
+    try {
+      fieldsFilterResponse = await p1FieldsFilter.run({
         dataStructure: rawCc,
         fieldsFilterString
-    });
-
-    if (typeof fieldsFilterResponse === "string") {
-        const error = new Error(
-            `p1FieldsFilter returned error response: ${fieldsFilterResponse}`
-        );
-
-        error.stage = "p1FieldsFilter";
-        error.vendorResponse = fieldsFilterResponse;
-        error.retryable = false;
-
-        throw error;
+      });
+    } catch (error) {
+      logger.error(
+        { label: "p1LoadRawCc:p1FieldsFilter", mountName, error: error.message || error },
+        "p1FieldsFilter threw an unexpected error"
+      );
+      throw new Error(ERRORS.RAW_CC_COULD_NOT_BE_PROVIDED);
     }
 
-    rawCc =
-    fieldsFilterResponse["filtered-data-structure"];
+    if (typeof fieldsFilterResponse !== "object" || !fieldsFilterResponse ||
+      !fieldsFilterResponse["filtered-data-structure"]
+    ) {
+      logger.error(
+        {
+          label: "p1LoadRawCc:p1FieldsFilter",
+          mountName,
+          response: fieldsFilterResponse
+        },
+        "Invalid p1FieldsFilter response"
+      );
+
+      throw new Error(ERRORS.RAW_CC_COULD_NOT_BE_PROVIDED);
+    }
+
+    //if (typeof fieldsFilterResponse === "string") {
+    //  const error = new Error(
+    //       `p1FieldsFilter returned error response: ${fieldsFilterResponse}`
+    //   );
+
+    //   error.stage = "p1FieldsFilter";
+    //   error.vendorResponse = fieldsFilterResponse;
+    //   error.retryable = false;
+
+    //   throw error;
+    //   logger.error(
+    //     { label: "p1LoadRawCc:p1FieldsFilter", mountName, vendorResponse: fieldsFilterResponse },
+    //     "p1FieldsFilter returned an error response"
+    //   );
+    //   throw new Error(ERRORS.RAW_CC_COULD_NOT_BE_PROVIDED);
+    // }
+
+    rawCc = fieldsFilterResponse["filtered-data-structure"];
     rawCc = normalizeRawCcAfterFieldsFilter(rawCc);
 
     /* if (!rawCc || typeof rawCc !== "object") {
@@ -428,13 +502,24 @@ async function run(request) {
         throw error;
     } */
 
-    const dataStoreClient = await onfAdapter.getEsClient(
-      false,
-      dataStoreEsClient.uuid,
-      dataStoreEsClient,
-      logger
-    );
+    // --- Get data store client ---
+    let dataStoreClient;
+    try {
+      dataStoreClient = await onfAdapter.getEsClient(
+        false,
+        dataStoreEsClient.uuid,
+        dataStoreEsClient,
+        logger
+      );
+    } catch (error) {
+      logger.error(
+        { label: "p1LoadRawCc:getDataStoreClient", error: error.message || error },
+        "Failed to initialize data store ES client"
+      );
+      throw new Error(ERRORS.DATA_STORE_ES_CLIENT_INVALID);
+    }
 
+    // --- Retrieve most recent period end times from data store ---
     const interfaceMetadataList = await loadInterfaceMetadataList(
       dataStoreClient,
       dataStoreEsClient["index-alias"],
@@ -449,6 +534,7 @@ async function run(request) {
       ".*"
     );
 
+    // --- Discard irrelevant PM records ---
     for (const ltp of rawCc["logical-termination-point"] || []) {
       const meta = interfaceMetadataList.find((item) => item.uuid === ltp.uuid) || {};
 
@@ -458,25 +544,30 @@ async function run(request) {
         if (layerProtocolName.includes("air-interface")) {
           const pac = layerProtocol["air-interface-2-0:air-interface-pac"] || {};
 
-          if(pac["air-interface-historical-performances"] && pac["air-interface-historical-performances"]["historical-performance-data-list"]
-             && pac["air-interface-historical-performances"]["historical-performance-data-list"].length > 0) {
-              pac["air-interface-historical-performances"] = await filterHistoricalList(
-                          pac["air-interface-historical-performances"],
-                          relevantGranularities,
-                          meta.mostRecentPeriodEndTime,
-                          meta.mostRecentPeriodEndTime24,
-                          logger
-                        );
-
-              layerProtocol["air-interface-2-0:air-interface-pac"] = pac;
+          if (
+            pac["air-interface-historical-performances"] &&
+            pac["air-interface-historical-performances"]["historical-performance-data-list"] &&
+            pac["air-interface-historical-performances"]["historical-performance-data-list"].length > 0
+          ) {
+            pac["air-interface-historical-performances"] = await filterHistoricalList(
+              pac["air-interface-historical-performances"],
+              relevantGranularities,
+              meta.mostRecentPeriodEndTime,
+              meta.mostRecentPeriodEndTime24,
+              logger
+            );
+            layerProtocol["air-interface-2-0:air-interface-pac"] = pac;
           }
-          
         }
 
         if (layerProtocolName.includes("ethernet-container")) {
           const pac = layerProtocol["ethernet-container-2-0:ethernet-container-pac"] || {};
-          if(pac["ethernet-container-historical-performances"] && pac["ethernet-container-historical-performances"]["historical-performance-data-list"]
-             && pac["ethernet-container-historical-performances"]["historical-performance-data-list"].length > 0) {
+
+          if (
+            pac["ethernet-container-historical-performances"] &&
+            pac["ethernet-container-historical-performances"]["historical-performance-data-list"] &&
+            pac["ethernet-container-historical-performances"]["historical-performance-data-list"].length > 0
+          ) {
             pac["ethernet-container-historical-performances"] = await filterHistoricalList(
               pac["ethernet-container-historical-performances"],
               relevantGranularities,
@@ -484,26 +575,30 @@ async function run(request) {
               meta.mostRecentPeriodEndTime24,
               logger
             );
-
             layerProtocol["ethernet-container-2-0:ethernet-container-pac"] = pac;
           }
         }
       }
     }
 
+    // --- Add batch timestamp ---
     addBatchTimestamp(rawCc);
 
     return { rawCc, mountName };
   } catch (error) {
-    error.stage = "p1LoadRawCc";
+    const message = String((error && error.message) || "");
+    if (ERRORS.knownErrors.has(message)) {
+      logger.error(
+        { label: "p1LoadRawCc", mountName, error: message },
+        message
+      );
+      throw error;
+    }
     logger.error(
-        {
-          label: "process-device-p1LoadRawCc",
-          error: error.message || error
-        },
-        "Failed to process device in p1LoadRawCc"
+      { label: "p1LoadRawCc", mountName, error: error.message || error },
+      "Unexpected error in p1LoadRawCc"
     );
-    throw error;
+    throw new Error(ERRORS.GENERAL_PROCESSING_ERROR);
   }
 }
 

--- a/server/specificFunctions/p1StreamPmData/p1ProcessDevice/p1LoadRawCc/P1LoadRawCc.test.js
+++ b/server/specificFunctions/p1StreamPmData/p1ProcessDevice/p1LoadRawCc/P1LoadRawCc.test.js
@@ -1,0 +1,916 @@
+jest.mock("../../../../infra/onf/onfAdapter", () => ({
+    getEsClient: jest.fn()
+}));
+
+jest.mock("../../../../utils/functionTree", () => ({
+    getParamFromFunction: jest.fn()
+}));
+
+jest.mock("../../../../utils/retry", () => ({
+    withRetry: jest.fn()
+}));
+
+jest.mock("../../../../genericFunctions/p1FieldsFilter/P1FieldsFilter", () => ({
+    run: jest.fn()
+}));
+
+jest.mock(
+    "../../../../genericFunctions/p1DiscardIrrelevantPmRecords/P1DiscardIrrelevantPmRecords",
+    () => jest.fn()
+);
+
+jest.mock("../../../../service/LoggingService.js", () => ({
+    getLogger: jest.fn(() => ({
+        info: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn()
+    }))
+}));
+
+const onfAdapter = require("../../../../infra/onf/onfAdapter");
+const { getParamFromFunction } = require("../../../../utils/functionTree");
+const { withRetry } = require("../../../../utils/retry");
+const p1FieldsFilter = require("../../../../genericFunctions/p1FieldsFilter/P1FieldsFilter");
+const p1DiscardIrrelevantPmRecords = require("../../../../genericFunctions/p1DiscardIrrelevantPmRecords/P1DiscardIrrelevantPmRecords");
+const ERRORS = require("./ErrorsEnum");
+const moduleUnderTest = require("./P1LoadRawCc");
+
+const validMwdiReplicaEsClient = {
+    uuid: "replica-uuid",
+    "index-alias": "replica-index"
+};
+
+const validDataStoreEsClient = {
+    uuid: "datastore-uuid",
+    "index-alias": "datastore-index"
+};
+
+const validRequest = {
+    parameters: { some: "params" },
+    mwdiReplicaEsClient: validMwdiReplicaEsClient,
+    dataStoreEsClient: validDataStoreEsClient,
+    mountName: "100250001"
+};
+
+const DEFAULT_BATCH_TIMESTAMP = "2010-11-20T14:00:00+01:00";
+
+describe("P1LoadRawCc Unit Tests", () => {
+    let mockReplicaClient;
+    let mockDataStoreClient;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        mockReplicaClient = {
+            get: jest.fn()
+        };
+
+        mockDataStoreClient = {
+            get: jest.fn()
+        };
+
+        onfAdapter.getEsClient
+            .mockResolvedValueOnce(mockReplicaClient)
+            .mockResolvedValueOnce(mockDataStoreClient);
+
+        withRetry.mockImplementation((fn) => fn());
+
+        mockReplicaClient.get.mockResolvedValue({
+            body: {
+                _source: {
+                    "core-model-1-4:control-construct": {
+                        uuid: "test-uuid"
+                    }
+                }
+            }
+        });
+
+        mockDataStoreClient.get.mockResolvedValue({
+            body: {
+                _source: {
+                    "interface-metadata-list": []
+                }
+            }
+        });
+
+        p1FieldsFilter.run.mockResolvedValue({
+            "filtered-data-structure": {
+                uuid: "test-uuid"
+            }
+        });
+
+        p1DiscardIrrelevantPmRecords.mockResolvedValue({
+            "filtered-historical-performance-data-list": []
+        });
+
+        getParamFromFunction
+            .mockReturnValueOnce("")
+            .mockReturnValueOnce(".*");
+    });
+
+    // ─── Module Validation ────────────────────────────────────────────────────
+
+    describe("Module Validation", () => {
+        test("should export run function", () => {
+            expect(moduleUnderTest.run).toBeDefined();
+            expect(typeof moduleUnderTest.run).toBe("function");
+        });
+    });
+
+    // ─── Input Validation ─────────────────────────────────────────────────────
+
+    describe("Input Validation", () => {
+        test("should throw PARAMETERS_NOT_PROVIDED when request is null", async () => {
+            await expect(
+                moduleUnderTest.run(null)
+            ).rejects.toThrow(ERRORS.PARAMETERS_NOT_PROVIDED);
+        });
+
+        test("should throw PARAMETERS_NOT_PROVIDED when request is undefined", async () => {
+            await expect(
+                moduleUnderTest.run(undefined)
+            ).rejects.toThrow(ERRORS.PARAMETERS_NOT_PROVIDED);
+        });
+
+        test("should throw PARAMETERS_NOT_PROVIDED when parameters is missing", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    parameters: undefined
+                })
+            ).rejects.toThrow(ERRORS.PARAMETERS_NOT_PROVIDED);
+        });
+
+        test("should throw PARAMETERS_INVALID when parameters is null", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    parameters: null
+                })
+            ).rejects.toThrow(ERRORS.PARAMETERS_NOT_PROVIDED);
+        });
+
+        test("should throw PARAMETERS_INVALID when parameters is a string", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    parameters: "invalid"
+                })
+            ).rejects.toThrow(ERRORS.PARAMETERS_INVALID);
+        });
+
+        test("should throw PARAMETERS_INVALID when parameters is an array", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    parameters: []
+                })
+            ).rejects.toThrow(ERRORS.PARAMETERS_INVALID);
+        });
+
+        test("should throw MWDI_REPLICA_ES_CLIENT_NOT_PROVIDED when mwdiReplicaEsClient is missing", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    mwdiReplicaEsClient: undefined
+                })
+            ).rejects.toThrow(ERRORS.MWDI_REPLICA_ES_CLIENT_NOT_PROVIDED);
+        });
+
+        test("should throw MWDI_REPLICA_ES_CLIENT_NOT_PROVIDED when mwdiReplicaEsClient is null", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    mwdiReplicaEsClient: null
+                })
+            ).rejects.toThrow(ERRORS.MWDI_REPLICA_ES_CLIENT_NOT_PROVIDED);
+        });
+
+        test("should throw MWDI_REPLICA_ES_CLIENT_INVALID when mwdiReplicaEsClient is not an object", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    mwdiReplicaEsClient: "invalid"
+                })
+            ).rejects.toThrow(ERRORS.MWDI_REPLICA_ES_CLIENT_INVALID);
+        });
+
+        test("should throw MWDI_REPLICA_ES_CLIENT_INVALID when mwdiReplicaEsClient is an array", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    mwdiReplicaEsClient: []
+                })
+            ).rejects.toThrow(ERRORS.MWDI_REPLICA_ES_CLIENT_INVALID);
+        });
+
+        test("should throw MWDI_REPLICA_ES_CLIENT_INVALID when mwdiReplicaEsClient.uuid is missing", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    mwdiReplicaEsClient: {
+                        "index-alias": "replica-index"
+                    }
+                })
+            ).rejects.toThrow(ERRORS.MWDI_REPLICA_ES_CLIENT_INVALID);
+        });
+
+        test("should throw MWDI_REPLICA_ES_CLIENT_INVALID when mwdiReplicaEsClient index-alias is missing", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    mwdiReplicaEsClient: {
+                        uuid: "replica-uuid"
+                    }
+                })
+            ).rejects.toThrow(ERRORS.MWDI_REPLICA_ES_CLIENT_INVALID);
+        });
+
+        test("should throw DATA_STORE_ES_CLIENT_NOT_PROVIDED when dataStoreEsClient is missing", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    dataStoreEsClient: undefined
+                })
+            ).rejects.toThrow(ERRORS.DATA_STORE_ES_CLIENT_NOT_PROVIDED);
+        });
+
+        test("should throw DATA_STORE_ES_CLIENT_NOT_PROVIDED when dataStoreEsClient is null", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    dataStoreEsClient: null
+                })
+            ).rejects.toThrow(ERRORS.DATA_STORE_ES_CLIENT_NOT_PROVIDED);
+        });
+
+        test("should throw DATA_STORE_ES_CLIENT_INVALID when dataStoreEsClient is not an object", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    dataStoreEsClient: 123
+                })
+            ).rejects.toThrow(ERRORS.DATA_STORE_ES_CLIENT_INVALID);
+        });
+
+        test("should throw DATA_STORE_ES_CLIENT_INVALID when dataStoreEsClient is an array", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    dataStoreEsClient: []
+                })
+            ).rejects.toThrow(ERRORS.DATA_STORE_ES_CLIENT_INVALID);
+        });
+
+        test("should throw DATA_STORE_ES_CLIENT_INVALID when dataStoreEsClient.uuid is missing", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    dataStoreEsClient: {
+                        "index-alias": "datastore-index"
+                    }
+                })
+            ).rejects.toThrow(ERRORS.DATA_STORE_ES_CLIENT_INVALID);
+        });
+
+        test("should throw DATA_STORE_ES_CLIENT_INVALID when dataStoreEsClient index-alias is missing", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    dataStoreEsClient: {
+                        uuid: "datastore-uuid"
+                    }
+                })
+            ).rejects.toThrow(ERRORS.DATA_STORE_ES_CLIENT_INVALID);
+        });
+
+        test("should throw MOUNT_NAME_NOT_PROVIDED when mountName is missing", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    mountName: undefined
+                })
+            ).rejects.toThrow(ERRORS.MOUNT_NAME_NOT_PROVIDED);
+        });
+
+        test("should throw MOUNT_NAME_NOT_PROVIDED when mountName is null", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    mountName: null
+                })
+            ).rejects.toThrow(ERRORS.MOUNT_NAME_NOT_PROVIDED);
+        });
+
+        test("should throw MOUNT_NAME_INVALID when mountName is not a string", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    mountName: 100250001
+                })
+            ).rejects.toThrow(ERRORS.MOUNT_NAME_INVALID);
+        });
+
+        test("should throw MOUNT_NAME_INVALID when mountName is an empty string", async () => {
+            await expect(
+                moduleUnderTest.run({
+                    ...validRequest,
+                    mountName: "   "
+                })
+            ).rejects.toThrow(ERRORS.MOUNT_NAME_INVALID);
+        });
+    });
+
+    // ─── Happy Path ───────────────────────────────────────────────────────────
+
+    describe("Happy Path", () => {
+        test("should return rawCc and mountName on success", async () => {
+            const result = await moduleUnderTest.run(validRequest);
+
+            expect(result).toHaveProperty("rawCc");
+            expect(result).toHaveProperty("mountName", validRequest.mountName);
+        });
+
+        test("should call getEsClient for replica and dataStore", async () => {
+            await moduleUnderTest.run(validRequest);
+
+            expect(onfAdapter.getEsClient).toHaveBeenCalledTimes(2);
+
+            expect(onfAdapter.getEsClient).toHaveBeenNthCalledWith(
+                1,
+                false,
+                validMwdiReplicaEsClient.uuid,
+                validMwdiReplicaEsClient,
+                expect.anything()
+            );
+
+            expect(onfAdapter.getEsClient).toHaveBeenNthCalledWith(
+                2,
+                false,
+                validDataStoreEsClient.uuid,
+                validDataStoreEsClient,
+                expect.anything()
+            );
+        });
+
+        test("should read ControlConstruct from replica using mountName", async () => {
+            await moduleUnderTest.run(validRequest);
+
+            expect(mockReplicaClient.get).toHaveBeenCalledTimes(1);
+            expect(mockReplicaClient.get).toHaveBeenCalledWith({
+                index: validMwdiReplicaEsClient["index-alias"],
+                id: validRequest.mountName
+            });
+        });
+
+        test("should read interface metadata from data store using mountName", async () => {
+            await moduleUnderTest.run(validRequest);
+
+            expect(mockDataStoreClient.get).toHaveBeenCalledTimes(1);
+            expect(mockDataStoreClient.get).toHaveBeenCalledWith({
+                index: validDataStoreEsClient["index-alias"],
+                id: validRequest.mountName
+            });
+        });
+
+        test("should call p1FieldsFilter.run with rawCc and fieldsFilterString", async () => {
+            await moduleUnderTest.run(validRequest);
+
+            expect(p1FieldsFilter.run).toHaveBeenCalledTimes(1);
+            expect(p1FieldsFilter.run).toHaveBeenCalledWith({
+                dataStructure: {
+                    uuid: "test-uuid"
+                },
+                fieldsFilterString: ""
+            });
+        });
+
+        test("should fall back to mountName object when rawCc is missing in replica response", async () => {
+            mockReplicaClient.get.mockResolvedValue({
+                body: {
+                    _source: {}
+                }
+            });
+
+            p1FieldsFilter.run.mockResolvedValue({
+                "filtered-data-structure": {
+                    mountName: validRequest.mountName
+                }
+            });
+
+            const result = await moduleUnderTest.run(validRequest);
+
+            expect(result.rawCc).toHaveProperty("mountName", validRequest.mountName);
+        });
+
+        test("should remove LTPs with no relevant layer protocols after fields filter", async () => {
+            p1FieldsFilter.run.mockResolvedValue({
+                "filtered-data-structure": {
+                    uuid: "test-uuid",
+                    "logical-termination-point": [
+                        {
+                            uuid: "ltp-irrelevant",
+                            "layer-protocol": [
+                                {
+                                    "layer-protocol-name": "some-other-protocol"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            const result = await moduleUnderTest.run(validRequest);
+
+            expect(result.rawCc["logical-termination-point"]).toEqual([]);
+        });
+
+        test("should keep LTPs that have air-interface-pac", async () => {
+            p1FieldsFilter.run.mockResolvedValue({
+                "filtered-data-structure": {
+                    uuid: "test-uuid",
+                    "logical-termination-point": [
+                        {
+                            uuid: "ltp-air",
+                            "layer-protocol": [
+                                {
+                                    "layer-protocol-name": "air-interface",
+                                    "air-interface-2-0:air-interface-pac": {
+                                        someField: "value"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            const result = await moduleUnderTest.run(validRequest);
+
+            expect(result.rawCc["logical-termination-point"]).toHaveLength(1);
+            expect(result.rawCc["logical-termination-point"][0].uuid).toBe("ltp-air");
+        });
+
+        test("should keep LTPs that have ethernet-container-pac", async () => {
+            p1FieldsFilter.run.mockResolvedValue({
+                "filtered-data-structure": {
+                    uuid: "test-uuid",
+                    "logical-termination-point": [
+                        {
+                            uuid: "ltp-eth",
+                            "layer-protocol": [
+                                {
+                                    "layer-protocol-name": "ethernet-container",
+                                    "ethernet-container-2-0:ethernet-container-pac": {
+                                        someField: "value"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            const result = await moduleUnderTest.run(validRequest);
+
+            expect(result.rawCc["logical-termination-point"]).toHaveLength(1);
+            expect(result.rawCc["logical-termination-point"][0].uuid).toBe("ltp-eth");
+        });
+
+        test("should clean current-performance-data-list and keep only granularity-period and timestamp", async () => {
+            p1FieldsFilter.run.mockResolvedValue({
+                "filtered-data-structure": {
+                    uuid: "test-uuid",
+                    "logical-termination-point": [
+                        {
+                            uuid: "ltp-air",
+                            "layer-protocol": [
+                                {
+                                    "layer-protocol-name": "air-interface",
+                                    "air-interface-2-0:air-interface-pac": {
+                                        "air-interface-current-performance": {
+                                            "current-performance-data-list": [
+                                                {
+                                                    "granularity-period": "PERIOD-15-MIN",
+                                                    timestamp: "2024-01-01T10:00:00Z",
+                                                    unwanted: "remove-me"
+                                                },
+                                                {
+                                                    "granularity-period": "",
+                                                    timestamp: "2024-01-01T11:00:00Z"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            const result = await moduleUnderTest.run(validRequest);
+
+            const cleanedList =
+                result.rawCc["logical-termination-point"][0]["layer-protocol"][0]
+                ["air-interface-2-0:air-interface-pac"]
+                ["air-interface-current-performance"]
+                ["current-performance-data-list"];
+
+            expect(cleanedList).toEqual([
+                {
+                    "granularity-period": "PERIOD-15-MIN",
+                    timestamp: "2024-01-01T10:00:00Z"
+                }
+            ]);
+        });
+
+        test("should set default batchTimestamp when no air-interface current performance data exists", async () => {
+            const result = await moduleUnderTest.run(validRequest);
+
+            expect(result.rawCc.batchTimestamp).toBe(DEFAULT_BATCH_TIMESTAMP);
+        });
+
+        test("should set batchTimestamp to latest timestamp from current performance data", async () => {
+            p1FieldsFilter.run.mockResolvedValue({
+                "filtered-data-structure": {
+                    uuid: "test-uuid",
+                    "logical-termination-point": [
+                        {
+                            uuid: "ltp-air",
+                            "layer-protocol": [
+                                {
+                                    "layer-protocol-name": "air-interface",
+                                    "air-interface-2-0:air-interface-pac": {
+                                        "air-interface-current-performance": {
+                                            "current-performance-data-list": [
+                                                {
+                                                    "granularity-period": "PERIOD-15-MIN",
+                                                    timestamp: "2024-01-01T10:00:00Z"
+                                                },
+                                                {
+                                                    "granularity-period": "PERIOD-15-MIN",
+                                                    timestamp: "2024-01-01T12:00:00Z"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            const result = await moduleUnderTest.run(validRequest);
+
+            expect(result.rawCc.batchTimestamp).toBe("2024-01-01T12:00:00Z");
+        });
+
+        test("should discard irrelevant air-interface historical PM records when list exists", async () => {
+            p1FieldsFilter.run.mockResolvedValue({
+                "filtered-data-structure": {
+                    uuid: "test-uuid",
+                    "logical-termination-point": [
+                        {
+                            uuid: "ltp-air",
+                            "layer-protocol": [
+                                {
+                                    "layer-protocol-name": "air-interface",
+                                    "air-interface-2-0:air-interface-pac": {
+                                        "air-interface-historical-performances": {
+                                            "historical-performance-data-list": [
+                                                {
+                                                    timestamp: "2024-01-01T00:00:00Z"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            p1DiscardIrrelevantPmRecords.mockResolvedValue({
+                "filtered-historical-performance-data-list": [
+                    {
+                        timestamp: "2024-01-02T00:00:00Z"
+                    }
+                ]
+            });
+
+            const result = await moduleUnderTest.run(validRequest);
+
+            const historicalPerformances =
+                result.rawCc["logical-termination-point"][0]["layer-protocol"][0]
+                ["air-interface-2-0:air-interface-pac"]
+                ["air-interface-historical-performances"];
+
+            expect(historicalPerformances).toEqual([
+                {
+                    timestamp: "2024-01-02T00:00:00Z"
+                }
+            ]);
+        });
+
+        test("should discard irrelevant ethernet-container historical PM records when list exists", async () => {
+            p1FieldsFilter.run.mockResolvedValue({
+                "filtered-data-structure": {
+                    uuid: "test-uuid",
+                    "logical-termination-point": [
+                        {
+                            uuid: "ltp-eth",
+                            "layer-protocol": [
+                                {
+                                    "layer-protocol-name": "ethernet-container",
+                                    "ethernet-container-2-0:ethernet-container-pac": {
+                                        "ethernet-container-historical-performances": {
+                                            "historical-performance-data-list": [
+                                                {
+                                                    timestamp: "2024-01-01T00:00:00Z"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            p1DiscardIrrelevantPmRecords.mockResolvedValue({
+                "filtered-historical-performance-data-list": [
+                    {
+                        timestamp: "2024-01-02T00:00:00Z"
+                    }
+                ]
+            });
+
+            const result = await moduleUnderTest.run(validRequest);
+
+            const historicalPerformances =
+                result.rawCc["logical-termination-point"][0]["layer-protocol"][0]
+                ["ethernet-container-2-0:ethernet-container-pac"]
+                ["ethernet-container-historical-performances"];
+
+            expect(historicalPerformances).toEqual([
+                {
+                    timestamp: "2024-01-02T00:00:00Z"
+                }
+            ]);
+        });
+
+        test("should pass mostRecentPeriodEndTime from matching interfaceMetadata item", async () => {
+            p1FieldsFilter.run.mockResolvedValue({
+                "filtered-data-structure": {
+                    uuid: "test-uuid",
+                    "logical-termination-point": [
+                        {
+                            uuid: "ltp-air-1",
+                            "layer-protocol": [
+                                {
+                                    "layer-protocol-name": "air-interface",
+                                    "air-interface-2-0:air-interface-pac": {
+                                        "air-interface-historical-performances": {
+                                            "historical-performance-data-list": [
+                                                {
+                                                    timestamp: "2024-01-01T00:00:00Z"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            mockDataStoreClient.get.mockResolvedValue({
+                body: {
+                    _source: {
+                        "interface-metadata-list": [
+                            {
+                                uuid: "ltp-air-1",
+                                mostRecentPeriodEndTime: "2024-01-01T00:00:00Z",
+                                mostRecentPeriodEndTime24: "2024-01-01T00:00:00Z"
+                            }
+                        ]
+                    }
+                }
+            });
+
+            await moduleUnderTest.run(validRequest);
+
+            expect(p1DiscardIrrelevantPmRecords).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    "most-recent-period-end-time": "2024-01-01T00:00:00Z",
+                    "most-recent-period-end-time-24": "2024-01-01T00:00:00Z"
+                })
+            );
+        });
+
+        test("should pass relevantGranularities from parameters", async () => {
+            getParamFromFunction
+                .mockReset()
+                .mockReturnValueOnce("fields-filter-value")
+                .mockReturnValueOnce(":GRANULARITY_PERIOD_TYPE_PERIOD-15-MIN$");
+
+            p1FieldsFilter.run.mockResolvedValue({
+                "filtered-data-structure": {
+                    uuid: "test-uuid",
+                    "logical-termination-point": [
+                        {
+                            uuid: "ltp-air",
+                            "layer-protocol": [
+                                {
+                                    "layer-protocol-name": "air-interface",
+                                    "air-interface-2-0:air-interface-pac": {
+                                        "air-interface-historical-performances": {
+                                            "historical-performance-data-list": [
+                                                {
+                                                    timestamp: "2024-01-01T00:00:00Z"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            await moduleUnderTest.run(validRequest);
+
+            expect(p1DiscardIrrelevantPmRecords).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    "relevant-granularities": ":GRANULARITY_PERIOD_TYPE_PERIOD-15-MIN$"
+                })
+            );
+        });
+    });
+
+    // ─── Error Path ───────────────────────────────────────────────────────────
+
+    describe("Error Path", () => {
+        test("should throw MWDI_REPLICA_ES_CLIENT_INVALID when getEsClient for replica fails", async () => {
+            onfAdapter.getEsClient.mockReset();
+            onfAdapter.getEsClient.mockRejectedValueOnce(
+                new Error("replica client error")
+            );
+
+            await expect(
+                moduleUnderTest.run(validRequest)
+            ).rejects.toThrow(ERRORS.MWDI_REPLICA_ES_CLIENT_INVALID);
+        });
+
+        test("should throw RAW_CC_COULD_NOT_BE_PROVIDED when replica read fails", async () => {
+            withRetry.mockReset();
+            withRetry.mockRejectedValueOnce(new Error("replica read failed"));
+
+            await expect(
+                moduleUnderTest.run(validRequest)
+            ).rejects.toThrow(ERRORS.RAW_CC_COULD_NOT_BE_PROVIDED);
+        });
+
+        test("should throw RAW_CC_COULD_NOT_BE_PROVIDED when p1FieldsFilter returns a string error", async () => {
+            p1FieldsFilter.run.mockResolvedValue("fields filter error");
+
+            await expect(
+                moduleUnderTest.run(validRequest)
+            ).rejects.toThrow(ERRORS.RAW_CC_COULD_NOT_BE_PROVIDED);
+        });
+
+        test("should throw RAW_CC_COULD_NOT_BE_PROVIDED when p1FieldsFilter throws", async () => {
+            p1FieldsFilter.run.mockRejectedValue(
+                new Error("fields filter internal error")
+            );
+
+            await expect(
+                moduleUnderTest.run(validRequest)
+            ).rejects.toThrow(ERRORS.RAW_CC_COULD_NOT_BE_PROVIDED);
+        });
+
+        test("should throw RAW_CC_COULD_NOT_BE_PROVIDED when p1FieldsFilter returns null", async () => {
+            p1FieldsFilter.run.mockResolvedValue(null);
+
+            await expect(
+                moduleUnderTest.run(validRequest)
+            ).rejects.toThrow(ERRORS.RAW_CC_COULD_NOT_BE_PROVIDED);
+        });
+
+        test("should throw RAW_CC_COULD_NOT_BE_PROVIDED when p1FieldsFilter response misses filtered-data-structure", async () => {
+            p1FieldsFilter.run.mockResolvedValue({});
+
+            await expect(
+                moduleUnderTest.run(validRequest)
+            ).rejects.toThrow(ERRORS.RAW_CC_COULD_NOT_BE_PROVIDED);
+        });
+
+        test("should throw DATA_STORE_ES_CLIENT_INVALID when getEsClient for dataStore fails", async () => {
+            onfAdapter.getEsClient.mockReset();
+            onfAdapter.getEsClient
+                .mockResolvedValueOnce(mockReplicaClient)
+                .mockRejectedValueOnce(new Error("datastore client error"));
+
+            await expect(
+                moduleUnderTest.run(validRequest)
+            ).rejects.toThrow(ERRORS.DATA_STORE_ES_CLIENT_INVALID);
+        });
+
+        test("should throw GENERAL_PROCESSING_ERROR when interface metadata loading fails", async () => {
+            withRetry.mockReset();
+            withRetry
+                .mockImplementationOnce((fn) => fn())
+                .mockRejectedValueOnce(new Error("datastore read failed"));
+
+            await expect(
+                moduleUnderTest.run(validRequest)
+            ).rejects.toThrow(ERRORS.GENERAL_PROCESSING_ERROR);
+        });
+
+        test("should throw GENERAL_PROCESSING_ERROR when p1DiscardIrrelevantPmRecords returns invalid response for air-interface", async () => {
+            p1FieldsFilter.run.mockResolvedValue({
+                "filtered-data-structure": {
+                    uuid: "test-uuid",
+                    "logical-termination-point": [
+                        {
+                            uuid: "ltp-air",
+                            "layer-protocol": [
+                                {
+                                    "layer-protocol-name": "air-interface",
+                                    "air-interface-2-0:air-interface-pac": {
+                                        "air-interface-historical-performances": {
+                                            "historical-performance-data-list": [
+                                                {
+                                                    timestamp: "2024-01-01T00:00:00Z"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            p1DiscardIrrelevantPmRecords.mockResolvedValue("invalid discard response");
+
+            await expect(
+                moduleUnderTest.run(validRequest)
+            ).rejects.toThrow(ERRORS.GENERAL_PROCESSING_ERROR);
+        });
+
+        test("should throw GENERAL_PROCESSING_ERROR when p1DiscardIrrelevantPmRecords returns invalid response for ethernet-container", async () => {
+            p1FieldsFilter.run.mockResolvedValue({
+                "filtered-data-structure": {
+                    uuid: "test-uuid",
+                    "logical-termination-point": [
+                        {
+                            uuid: "ltp-eth",
+                            "layer-protocol": [
+                                {
+                                    "layer-protocol-name": "ethernet-container",
+                                    "ethernet-container-2-0:ethernet-container-pac": {
+                                        "ethernet-container-historical-performances": {
+                                            "historical-performance-data-list": [
+                                                {
+                                                    timestamp: "2024-01-01T00:00:00Z"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            p1DiscardIrrelevantPmRecords.mockResolvedValue("invalid discard response");
+
+            await expect(
+                moduleUnderTest.run(validRequest)
+            ).rejects.toThrow(ERRORS.GENERAL_PROCESSING_ERROR);
+        });
+
+        test("should throw GENERAL_PROCESSING_ERROR for unexpected errors", async () => {
+            getParamFromFunction.mockReset();
+
+            getParamFromFunction.mockImplementation(() => {
+                throw new Error("unexpected crash");
+            });
+
+            await expect(
+                moduleUnderTest.run(validRequest)
+            ).rejects.toThrow(ERRORS.GENERAL_PROCESSING_ERROR);
+        });
+    });
+});
+
+


### PR DESCRIPTION
### Summary
Added p1LoadRawCc module along with test cases and error handling.

### Changes
- Added P1LoadRawCc.js
- Added P1LoadRawCc.test.js
- Added ErrorEnums.js

### Bug Fix
- Fixed `inputRecordCount` calculation in `filterHistoricalList`.
- Replaced `list.length` with a safe length check on `list["historical-performance-data-list"]`, since `list` is an object and not an array.
