### PR TITLE
Fix batch timestamp retrieval in p1Storing

### DIFF
--- a/server/genericFunctions/p1RemoveOutOfRangeTemperature/P1RemoveOutOfRangeTemperature.js
+++ b/server/genericFunctions/p1RemoveOutOfRangeTemperature/P1RemoveOutOfRangeTemperature.js
@@ -144,13 +144,13 @@ const p1RemoveOutOfRangeTemperature = (input) => {
     equipClean.forEach(equip => {
       if (equip["actual-equipment"] && equip["actual-equipment"]["physical-properties"]) {
         if (equip["actual-equipment"]["physical-properties"]["temperature"] == "") {
-          delete equip["actual-equipment"]["physical-properties"]["temperature"];
-        }
-
-        if (lowParam > parseInt(equip["actual-equipment"]["physical-properties"]["temperature"]) ||
-          upperParam < parseInt(equip["actual-equipment"]["physical-properties"]["temperature"])) {
-          delete equip["actual-equipment"]["physical-properties"]["temperature"];
-        }
+          delete equip["actual-equipment"]["physical-properties"];
+        } else {
+          if (lowParam > parseInt(equip["actual-equipment"]["physical-properties"]["temperature"]) ||
+            upperParam < parseInt(equip["actual-equipment"]["physical-properties"]["temperature"])) {
+            delete equip["actual-equipment"]["physical-properties"];
+          }
+      }
       }
     });
 

--- a/server/specificFunctions/p1StreamPmData/ErrorsEnum.js
+++ b/server/specificFunctions/p1StreamPmData/ErrorsEnum.js
@@ -1,0 +1,13 @@
+const ERRORS = {
+  PARAMETERS_NOT_PROVIDED: "Parameters could not be loaded",
+  PARAMETERS_INVALID: "Parameters missing or invalid",
+  CONFIG_FILE_NOT_PROVIDED: "Config file missing or invalid",
+  CONFIG_FILE_INVALID: "Config file missing or invalid",
+  ES_ADDRESS_NOT_RESOLVED: "ES address could not be resolved",
+  KAFKA_SESSION_NOT_ESTABLISHED: "Kafka session could not be established",
+  GENERAL_PROCESSING_ERROR: "General processing error"
+};
+
+ERRORS.knownErrors = new Set(Object.values(ERRORS));
+
+module.exports = ERRORS;

--- a/server/specificFunctions/p1StreamPmData/P1StreamPmData.js
+++ b/server/specificFunctions/p1StreamPmData/P1StreamPmData.js
@@ -20,39 +20,84 @@ const { startReplicaLeaderLoop } = require("../../runtime/replica/replicaLeaderL
 const { startProcessingWorkerPoolRedis } = require("../../runtime/processing/processingWorkerPoolRedis");
 const { startKafkaOutboundWorkerPool } = require("../../runtime/kafka/kafkaOutboundWorker");
 const { startRetryWorkerPool } = require("../../runtime/processing/retryWorker");
+const ERRORS = require("./ErrorsEnum");
 
 const logger = require('../../service/LoggingService.js').getLogger();
 const appState = new AppState();
 
+function buildProcessingError(message, stage = "p1StreamPmData", details) {
+  const error = new Error(message);
+  error.stage = stage;
+
+  if (details) {
+    error.details = details;
+  }
+
+  return error;
+}
+
+function normalizeProcessingError(error) {
+  const message = String(error?.message || error || "");
+  const normalized = message.toLowerCase();
+
+  if (normalized.includes("parameter") || normalized.includes("functionname")) {
+    return buildProcessingError(ERRORS.PARAMETERS_INVALID, error?.stage || "p1StreamPmData", {
+      originalError: error
+    });
+  }
+
+  if (normalized.includes("config")) {
+    return buildProcessingError(ERRORS.CONFIG_FILE_NOT_PROVIDED, error?.stage || "p1StreamPmData", {
+      originalError: error
+    });
+  }
+
+  if (normalized.includes("es address") || normalized.includes("elastic")) {
+    return buildProcessingError(ERRORS.ES_ADDRESS_NOT_RESOLVED, error?.stage || "p1StreamPmData", {
+      originalError: error
+    });
+  }
+
+  if (normalized.includes("kafka")) {
+    return buildProcessingError(ERRORS.KAFKA_SESSION_NOT_ESTABLISHED, error?.stage || "p1StreamPmData", {
+      originalError: error
+    });
+  }
+
+  return buildProcessingError(ERRORS.GENERAL_PROCESSING_ERROR, error?.stage || "p1StreamPmData", {
+    originalError: error
+  });
+}
+
 
 async function startCleanupLeaderLoop(context) {
-    const lockKey = "dpmdp:lock:cleanup";
-    const ttlMs = context.cleanupLockTtlMs || 300000;
-    const cleanupPeriodHours = Number(
-        getParamFromFunction(context.cleanupParameters, "p1MaintainDs", "dataStoreCleanupPeriod", 12)
-    );
+  const lockKey = "dpmdp:lock:cleanup";
+  const ttlMs = context.cleanupLockTtlMs || 300000;
+  const cleanupPeriodHours = Number(
+    getParamFromFunction(context.cleanupParameters, "p1MaintainDs", "dataStoreCleanupPeriod", 12)
+  );
 
-    while (true) {
-        const token = await acquireLock(lockKey, ttlMs, context.logger);
+  while (true) {
+    const token = await acquireLock(lockKey, ttlMs, context.logger);
 
-        if (!token) {
-            await sleep(10000);
-            continue;
-        }
-
-        try {
-            await p1MaintainDs.run({
-                parameters: context.cleanupParameters,
-                dataStoreEsClient: context.dataStoreEsClient,
-                loggingEsClient: context.loggingEsClient,
-                logger: context.logger
-            });
-        } finally {
-            await releaseLock(lockKey, token, context.logger).catch(() => {});
-        }
-
-        await sleep(cleanupPeriodHours * 3600 * 1000);
+    if (!token) {
+      await sleep(10000);
+      continue;
     }
+
+    try {
+      await p1MaintainDs.run({
+        parameters: context.cleanupParameters,
+        dataStoreEsClient: context.dataStoreEsClient,
+        loggingEsClient: context.loggingEsClient,
+        logger: context.logger
+      });
+    } finally {
+      await releaseLock(lockKey, token, context.logger).catch(() => { });
+    }
+
+    await sleep(cleanupPeriodHours * 3600 * 1000);
+  }
 }
 
 /**
@@ -68,170 +113,186 @@ async function startCleanupLeaderLoop(context) {
  * }
  */
 async function run() {
-  const sequence = [];
+  try {
+    const runtimeConfig = loadRuntimeConfig() || {};
+    const redisConfig = runtimeConfig.redis || {};
+    const serviceConfig = runtimeConfig.service || {};
 
-  const runtimeConfig = loadRuntimeConfig() || {};
-  const redisConfig = runtimeConfig.redis || {};
-  const serviceConfig = runtimeConfig.service || {};
+    const instanceId = `${os.hostname()}-${process.pid}-${crypto.randomUUID()}`;
 
-  const instanceId = `${os.hostname()}-${process.pid}-${crypto.randomUUID()}`;
+    registerGracefulShutdown(appState, logger, {
+      shutdownGraceMs: (((runtimeConfig || {}).service || {}).shutdownGraceMs) || 30000
+    });
 
-  registerGracefulShutdown(appState, logger, {
-    shutdownGraceMs: (((runtimeConfig || {}).service || {}).shutdownGraceMs) || 30000
-  });
+    /* startMonitoringServer(appState, logger, {
+      enabled: ((((runtimeConfig || {}).monitoring || {}).enabled) !== false),
+      port: ((((runtimeConfig || {}).service || {}).httpPort) || 8040)
+    }); */
 
-  /* startMonitoringServer(appState, logger, {
-    enabled: ((((runtimeConfig || {}).monitoring || {}).enabled) !== false),
-    port: ((((runtimeConfig || {}).service || {}).httpPort) || 8040)
-  }); */
+    const loaded = await p1LoadParameters.run({
+      functionName: "p1StreamPmData",
+    });
 
-  const loaded = await p1LoadParameters.run({
-    functionName: "p1StreamPmData",
-  });
+    const p1ResolveEsAddressParameters = findFunctionNode(loaded.parameters, "p1ResolveEsAddress");
+    const p1InitKafkaParameters = findFunctionNode(loaded.parameters, "p1InitKafka");
+    const p1UpdateMwdiReplicaParameters = findFunctionNode(loaded.parameters, "p1UpdateMwdiReplica");
+    const p1ProcessDeviceParameters = findFunctionNode(loaded.parameters, "p1ProcessDevice");
+    const p1TransmittingKafkaParameters = findFunctionNode(loaded.parameters, "p1TransmittingKafka");
+    const p1MaintainDsParameters = findFunctionNode(loaded.parameters, "p1MaintainDs");
 
-  const p1ResolveEsAddressParameters = findFunctionNode(loaded.parameters, "p1ResolveEsAddress");
-  const p1InitKafkaParameters = findFunctionNode(loaded.parameters, "p1InitKafka");
-  const p1UpdateMwdiReplicaParameters = findFunctionNode(loaded.parameters, "p1UpdateMwdiReplica");
-  const p1ProcessDeviceParameters = findFunctionNode(loaded.parameters, "p1ProcessDevice");
-  const p1TransmittingKafkaParameters = findFunctionNode(loaded.parameters, "p1TransmittingKafka");
-  const p1MaintainDsParameters = findFunctionNode(loaded.parameters, "p1MaintainDs");
+    const mwdiEsClient = (
+      await p1ResolveESAddress.run({
+        parameters: p1ResolveEsAddressParameters,
+        configFile: loaded.configFile,
+        esName: "mwdiEsClient"
+      })
+    ).esAddress;
 
-  const mwdiEsClient = (
-    await p1ResolveESAddress.run({
-      parameters: p1ResolveEsAddressParameters,
+    const mwdiReplicaEsClient = (
+      await p1ResolveESAddress.run({
+        parameters: p1ResolveEsAddressParameters,
+        configFile: loaded.configFile,
+        esName: "mwdiReplicaEsClient"
+      })
+    ).esAddress;
+
+    const loggingEsClient = (
+      await p1ResolveESAddress.run({
+        parameters: p1ResolveEsAddressParameters,
+        configFile: loaded.configFile,
+        esName: "loggingEsClient"
+      })
+    ).esAddress;
+
+    const dataStoreEsClient = (
+      await p1ResolveESAddress.run({
+        parameters: p1ResolveEsAddressParameters,
+        configFile: loaded.configFile,
+        esName: "dataStoreEsClient"
+      })
+    ).esAddress;
+
+    await ensureIndicesAndMappings(
+      {
+        mwdiReplicaEsClient,
+        loggingEsClient,
+        dataStoreEsClient
+      },
+      logger
+    );
+
+    const restoredLastReplicaTime = await loadLastReplicaTime(loggingEsClient, logger);
+
+    appState.lastReplicaTime = restoredLastReplicaTime;
+
+    const kafkaInit = await p1InitKafka.run({
+      parameters: p1InitKafkaParameters,
       configFile: loaded.configFile,
-      esName: "mwdiEsClient"
-    })
-  ).esAddress;
+      logger
+    });
 
-  const mwdiReplicaEsClient = (
-    await p1ResolveESAddress.run({
-      parameters: p1ResolveEsAddressParameters,
-      configFile: loaded.configFile,
-      esName: "mwdiReplicaEsClient"
-    })
-  ).esAddress;
 
-  const loggingEsClient = (
-    await p1ResolveESAddress.run({
-      parameters: p1ResolveEsAddressParameters,
-      configFile: loaded.configFile,
-      esName: "loggingEsClient"
-    })
-  ).esAddress;
-
-  const dataStoreEsClient = (
-    await p1ResolveESAddress.run({
-      parameters: p1ResolveEsAddressParameters,
-      configFile: loaded.configFile,
-      esName: "dataStoreEsClient"
-    })
-  ).esAddress;
-
-  await ensureIndicesAndMappings(
-    {
+    startReplicaLeaderLoop({
+      logger,
+      appState,
+      updateParameters: p1UpdateMwdiReplicaParameters,
+      mwdiEsClient,
       mwdiReplicaEsClient,
       loggingEsClient,
-      dataStoreEsClient
-    },
-    logger
-  );
+      maxQueueLengthBeforeReplicaPause: Number(redisConfig.maxQueueLengthBeforeReplicaPause) || 20000,
+      replicaPauseMsWhenBacklogged: Number(redisConfig.replicaPauseMsWhenBacklogged) || 30000,
+      replicaLockTtlMs: redisConfig.replicaLockTtlMs || 60000
+    }).catch((error) => logger.error({ error }, `Replica leader loop crashed: ${error.message || error}`));
 
-  const restoredLastReplicaTime = await loadLastReplicaTime(loggingEsClient, logger);
+    startProcessingWorkerPoolRedis({
+      logger,
+      instanceId,
+      appState,
+      workerCount: Number(serviceConfig.concurrency || 4),
+      processDeviceParameters: p1ProcessDeviceParameters,
+      kafkaConsumerTypes: serviceConfig.kafkaConsumerTypes,
+      configFile: loaded.configFile,
+      mwdiReplicaEsClient,
+      dataStoreEsClient,
+      staleMessageIdleMs: Number(redisConfig.staleMessageIdleMs || 60000),
+      workerIdleSleepMs: Number(serviceConfig.workerIdleSleepMs || 1000),
+      // retry control
+      maxRetryCount: Number(redisConfig.maxRetryCount || 1),
+      deviceProcessingLockTtlMs: Number(redisConfig.deviceProcessingLockTtlMs || 30 * 60 * 1000)
+    }).catch((error) => logger.error({ error }, "Worker pool crashed"));
 
-  appState.lastReplicaTime = restoredLastReplicaTime;
-
-  const kafkaInit = await p1InitKafka.run({
-    parameters: p1InitKafkaParameters,
-    configFile: loaded.configFile,
-    logger
-  });
-
-  
-  startReplicaLeaderLoop({
-    logger,
-    appState,
-    updateParameters: p1UpdateMwdiReplicaParameters,
-    mwdiEsClient,
-    mwdiReplicaEsClient,
-    loggingEsClient,
-    maxQueueLengthBeforeReplicaPause: Number(redisConfig.maxQueueLengthBeforeReplicaPause) || 20000,
-    replicaPauseMsWhenBacklogged: Number(redisConfig.replicaPauseMsWhenBacklogged) || 30000,
-    replicaLockTtlMs: redisConfig.replicaLockTtlMs || 60000
-  }).catch((error) => logger.error({ error }, `Replica leader loop crashed: ${error.message || error}`));
-
-  startProcessingWorkerPoolRedis({
-    logger,
-    instanceId,
-    appState,
-    workerCount: Number(serviceConfig.concurrency || 4),
-    processDeviceParameters: p1ProcessDeviceParameters,
-    kafkaConsumerTypes: serviceConfig.kafkaConsumerTypes,
-    configFile: loaded.configFile,
-    mwdiReplicaEsClient,
-    dataStoreEsClient,
-    staleMessageIdleMs: Number(redisConfig.staleMessageIdleMs || 60000),
-    workerIdleSleepMs: Number(serviceConfig.workerIdleSleepMs || 1000),
-    // retry control
-    maxRetryCount: Number(redisConfig.maxRetryCount || 1),
-    deviceProcessingLockTtlMs: Number(redisConfig.deviceProcessingLockTtlMs || 30 * 60 * 1000)
-  }).catch((error) => logger.error({ error }, "Worker pool crashed"));
-
-  startKafkaOutboundWorkerPool({
-    logger,
-    instanceId,
-    appState,
-    dataStoreEsClient,
-    p1TransmittingKafkaParameters,
-    kafkaConnectionList: kafkaInit.kafkaConnectionList,
-    workerCount: Number(serviceConfig.kafkaOutboundConcurrency || 1),
-    readCount: Number(serviceConfig.kafkaOutboundReadCount || 100),
-    batchSize: Number(serviceConfig.kafkaOutboundBatchSize || 100),
-    maxBatchBytes: Number(serviceConfig.kafkaOutboundMaxBatchBytes || 900 * 1024),
-    staleMessageIdleMs: Number(serviceConfig.kafkaOutboundStaleMessageIdleMs  || 60000),
-    kafkaFailureSleepMs: Number(serviceConfig.kafkaOutboundFailureSleepMs || 10000),
-    workerIdleSleepMs: Number(serviceConfig.kafkaOutboundWorkerIdleSleepMs || 1000),
+    startKafkaOutboundWorkerPool({
+      logger,
+      instanceId,
+      appState,
+      dataStoreEsClient,
+      p1TransmittingKafkaParameters,
+      kafkaConnectionList: kafkaInit.kafkaConnectionList,
+      workerCount: Number(serviceConfig.kafkaOutboundConcurrency || 1),
+      readCount: Number(serviceConfig.kafkaOutboundReadCount || 100),
+      batchSize: Number(serviceConfig.kafkaOutboundBatchSize || 100),
+      maxBatchBytes: Number(serviceConfig.kafkaOutboundMaxBatchBytes || 900 * 1024),
+      staleMessageIdleMs: Number(serviceConfig.kafkaOutboundStaleMessageIdleMs || 60000),
+      kafkaFailureSleepMs: Number(serviceConfig.kafkaOutboundFailureSleepMs || 10000),
+      workerIdleSleepMs: Number(serviceConfig.kafkaOutboundWorkerIdleSleepMs || 1000),
       // kafka producer config for sendBatch
-    kafkaProducerMessageMaxBytes:serviceConfig.kafkaProducerMessageMaxBytes || 5242880,
-    kafkaSocketRequestMaxBytes:serviceConfig.kafkaSocketRequestMaxBytes || 10485760,
-    kafkaMaxSingleMessageBytes:serviceConfig.kafkaMaxSingleMessageBytes || 4500000,
-    kafkaOversizedMessageMode:serviceConfig.kafkaOversizedMessageMode || "ERROR"
-  }).catch((error) =>
-    logger.error({ error }, "Kafka outbound worker pool crashed")
-  );
+      kafkaProducerMessageMaxBytes: serviceConfig.kafkaProducerMessageMaxBytes || 5242880,
+      kafkaSocketRequestMaxBytes: serviceConfig.kafkaSocketRequestMaxBytes || 10485760,
+      kafkaMaxSingleMessageBytes: serviceConfig.kafkaMaxSingleMessageBytes || 4500000,
+      kafkaOversizedMessageMode: serviceConfig.kafkaOversizedMessageMode || "ERROR"
+    }).catch((error) =>
+      logger.error({ error }, "Kafka outbound worker pool crashed")
+    );
 
-  startRetryWorkerPool({
-    logger,
-    instanceId,
-    appState,
-     // keep one retry worker; it only requeues metadata, not full CCs
-    workerCount: Number(redisConfig.retryWorkerCount || 1),
-     // run retry cycle every 2 hours by default
-    retryIntervalMs: Number(redisConfig.retryIntervalMs || 2 * 60 * 60 * 1000),
-    // read small chunks, not 10k/20k into memory
-    retryReadCount: Number(redisConfig.retryReadCount || 500),
-     // allow large retry queue, but requeue up to this per cycle
-    retryMaxRequeuePerCycle: Number(redisConfig.retryMaxRequeuePerCycle || 20000),
+    startRetryWorkerPool({
+      logger,
+      instanceId,
+      appState,
+      // keep one retry worker; it only requeues metadata, not full CCs
+      workerCount: Number(redisConfig.retryWorkerCount || 1),
+      // run retry cycle every 2 hours by default
+      retryIntervalMs: Number(redisConfig.retryIntervalMs || 2 * 60 * 60 * 1000),
+      // read small chunks, not 10k/20k into memory
+      retryReadCount: Number(redisConfig.retryReadCount || 500),
+      // allow large retry queue, but requeue up to this per cycle
+      retryMaxRequeuePerCycle: Number(redisConfig.retryMaxRequeuePerCycle || 20000),
 
-    staleMessageIdleMs: Number(redisConfig.staleMessageIdleMs || 60000),
+      staleMessageIdleMs: Number(redisConfig.staleMessageIdleMs || 60000),
 
-    // false means do not retry immediately on startup
-    retryRunImmediately: redisConfig.retryRunImmediately === true,
-  }).catch((error) => logger.error({ error }, "Retry worker pool crashed")); 
+      // false means do not retry immediately on startup
+      retryRunImmediately: redisConfig.retryRunImmediately === true,
+    }).catch((error) => logger.error({ error }, "Retry worker pool crashed"));
 
-  startCleanupLeaderLoop({
-    logger,
-    cleanupParameters: p1MaintainDsParameters,
-    dataStoreEsClient,
-    loggingEsClient,
-    cleanupLockTtlMs: redisConfig.cleanupLockTtlMs || 300000
-  }).catch((error) => logger.error({ error }, "Cleanup leader loop crashed"));
+    startCleanupLeaderLoop({
+      logger,
+      cleanupParameters: p1MaintainDsParameters,
+      dataStoreEsClient,
+      loggingEsClient,
+      cleanupLockTtlMs: redisConfig.cleanupLockTtlMs || 300000
+    }).catch((error) => logger.error({ error }, "Cleanup leader loop crashed"));
 
-  return {
-    instanceId,
-    appState,
-    kafkaConnectionList: kafkaInit.kafkaConnectionList
-  };
+    return {
+      instanceId,
+      appState,
+      kafkaConnectionList: kafkaInit.kafkaConnectionList
+    };
+  } catch (error) {
+    const normalizedError = normalizeProcessingError(error);
+
+    logger.error(
+      {
+        label: "p1-stream-pm-data",
+        error: normalizedError.message || error
+      },
+      "Failed to initialize stream pm data"
+    );
+
+    throw {
+      stage: normalizedError.stage,
+      message: normalizedError.message,
+      details: normalizedError.details,
+      originalError: error
+    };
+  }
 }
-
 module.exports = { run };

--- a/server/specificFunctions/p1StreamPmData/P1StreamPmData.test.js
+++ b/server/specificFunctions/p1StreamPmData/P1StreamPmData.test.js
@@ -1,0 +1,153 @@
+jest.mock("../../utils/config", () => ({
+  loadRuntimeConfig: jest.fn()
+}));
+
+jest.mock("../../utils/functionTree", () => ({
+  findFunctionNode: jest.fn(),
+  getParamFromFunction: jest.fn()
+}));
+
+jest.mock("../../infra/redis/redisLock", () => ({
+  acquireLock: jest.fn(),
+  releaseLock: jest.fn()
+}));
+
+jest.mock("../../utils/retry", () => ({
+  sleep: jest.fn().mockResolvedValue(undefined)
+}));
+
+jest.mock("../../core/appState", () => ({
+  AppState: jest.fn().mockImplementation(() => ({
+    lastReplicaTime: null
+  }))
+}));
+
+jest.mock("../../core/gracefulShutdown", () => ({
+  registerGracefulShutdown: jest.fn()
+}));
+
+jest.mock("../../core/monitoringServer", () => ({
+  startMonitoringServer: jest.fn()
+}));
+
+jest.mock("../../infra/elasticSearch/esBootstrap.js", () => ({
+  ensureIndicesAndMappings: jest.fn().mockResolvedValue(undefined)
+}));
+
+jest.mock("../../core/replicaStateStore.js", () => ({
+  loadLastReplicaTime: jest.fn().mockResolvedValue("2024-01-01T00:00:00Z")
+}));
+
+jest.mock("../../genericFunctions/p1LoadParameters/P1LoadParameters", () => ({
+  run: jest.fn()
+}));
+
+jest.mock("../../genericFunctions/p1ResolveEsAddress/P1ResolveEsAddress", () => ({
+  run: jest.fn()
+}));
+
+jest.mock("../../genericFunctions/p1InitKafka/P1InitKafka", () => ({
+  run: jest.fn()
+}));
+
+jest.mock("./p1MaintainDs/P1MaintainDs", () => ({
+  run: jest.fn()
+}));
+
+jest.mock("../../runtime/replica/replicaLeaderLoop", () => ({
+  startReplicaLeaderLoop: jest.fn().mockReturnValue(Promise.resolve())
+}));
+
+jest.mock("../../runtime/processing/processingWorkerPoolRedis", () => ({
+  startProcessingWorkerPoolRedis: jest.fn().mockReturnValue(Promise.resolve())
+}));
+
+jest.mock("../../runtime/kafka/kafkaOutboundWorker", () => ({
+  startKafkaOutboundWorkerPool: jest.fn().mockReturnValue(Promise.resolve())
+}));
+
+jest.mock("../../runtime/processing/retryWorker", () => ({
+  startRetryWorkerPool: jest.fn().mockReturnValue(Promise.resolve())
+}));
+
+jest.mock("../../service/LoggingService.js", () => ({
+  getLogger: () => ({
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn()
+  })
+}));
+
+const { loadRuntimeConfig } = require("../../utils/config");
+const { findFunctionNode } = require("../../utils/functionTree");
+const p1LoadParameters = require("../../genericFunctions/p1LoadParameters/P1LoadParameters");
+const p1ResolveESAddress = require("../../genericFunctions/p1ResolveEsAddress/P1ResolveEsAddress");
+const p1InitKafka = require("../../genericFunctions/p1InitKafka/P1InitKafka");
+const { run } = require("./P1StreamPmData");
+const ERRORS = require("./ErrorsEnum");
+
+function mockLoadedParameters() {
+  findFunctionNode.mockImplementation((parameters, functionName) => {
+    if (functionName === "p1ResolveEsAddress") return {};
+    if (functionName === "p1InitKafka") return {};
+    if (functionName === "p1UpdateMwdiReplica") return {};
+    if (functionName === "p1ProcessDevice") return {};
+    if (functionName === "p1TransmittingKafka") return {};
+    if (functionName === "p1MaintainDs") return {};
+    return {};
+  });
+
+  p1LoadParameters.run.mockResolvedValue({
+    parameters: { test: "config" },
+    configFile: { test: "config" }
+  });
+
+  p1ResolveESAddress.run.mockImplementation(async ({ esName }) => ({
+    esAddress: { uuid: esName }
+  }));
+
+  p1InitKafka.run.mockResolvedValue({
+    kafkaConnectionList: [{ topicName: "topic-a" }]
+  });
+}
+
+describe("P1StreamPmData", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    loadRuntimeConfig.mockReturnValue({
+      redis: {},
+      service: {
+        concurrency: 1,
+        kafkaOutboundConcurrency: 1,
+        kafkaConsumerTypes: "APT,ONF"
+      }
+    });
+
+    mockLoadedParameters();
+  });
+
+  test("exports a run function", () => {
+    expect(typeof run).toBe("function");
+  });
+
+  test("returns initialized service information on success", async () => {
+    const result = await run();
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        instanceId: expect.any(String),
+        appState: expect.any(Object),
+        kafkaConnectionList: [{ topicName: "topic-a" }]
+      })
+    );
+  });
+
+  test("normalizes parameter loading failures as the interface error contract", async () => {
+    p1LoadParameters.run.mockRejectedValue(new Error("functionName not found in configFile"));
+
+    await expect(run()).rejects.toMatchObject({
+      message: ERRORS.PARAMETERS_INVALID
+    });
+  });
+});

--- a/server/specificFunctions/p1StreamPmData/p1ProcessDevice/ErrorsEnum.js
+++ b/server/specificFunctions/p1StreamPmData/p1ProcessDevice/ErrorsEnum.js
@@ -1,0 +1,16 @@
+const ERRORS = {
+  INPUT_DATA_MISSING_OR_INVALID: "Input data missing or invalid",
+  MOUNT_NAME_NOT_FOUND: "Mount name not found",
+  PARAMETERS_MISSING_OR_INVALID: "Parameters missing or invalid",
+  CONFIG_FILE_MISSING_OR_INVALID: "Config file missing or invalid",
+  RAW_CC_DATA_MISSING_OR_INVALID: "Raw CC data missing or invalid",
+  RESULT_CC_DATA_MISSING_OR_INVALID: "Result CC data missing or invalid",
+  OUTPUT_FORMAT_MISSING_OR_INVALID: "Output format missing or invalid",
+  KAFKA_TRANSMISSION_FAILED: "Kafka transmission failed",
+  STORING_RESULT_CC_FAILED: "Storing resultCc failed",
+  GENERAL_PROCESSING_ERROR: "General processing error"
+};
+
+ERRORS.knownErrors = new Set(Object.values(ERRORS));
+
+module.exports = ERRORS;

--- a/server/specificFunctions/p1StreamPmData/p1ProcessDevice/P1ProcessDevice.js
+++ b/server/specificFunctions/p1StreamPmData/p1ProcessDevice/P1ProcessDevice.js
@@ -4,6 +4,7 @@ const redisQueueKafkaOutbound = require("../../../infra/kafka/queueKafkaOutbound
 const p1Storing = require("./p1Storing/P1Storing");
 const { findFunctionNode } = require("../../../utils/functionTree.js");
 const logger = require('../../../service/LoggingService.js').getLogger();
+const ERRORS = require('./ErrorsEnum');
 const formatAptOutputErrors = require('./p1FormattingOutputApt/ErrorsEnum');
 const p1FormattingOutputApt = require("./p1FormattingOutputApt/P1FormattingOutputApt");
 const formatOnfOutputErrors = require('./p1FormattingOutputOnf/ErrorsEnum');
@@ -11,6 +12,164 @@ const p1FormattingOutputOnf = require("./p1FormattingOutputOnf/P1FormattingOutpu
 const fs = require("fs");
 const sampleResultCcApt = require("./outputAPTSample.json");
 const sampleResultCcOnf = require("./outputOnfSample.json");
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function getRequestValue(request, ...keys) {
+  if (!request || typeof request !== "object" || Array.isArray(request)) {
+    return undefined;
+  }
+
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(request, key)) {
+      return request[key];
+    }
+  }
+
+  return undefined;
+}
+
+function buildProcessingError(message, stage = "p1ProcessDevice", details) {
+  const error = new Error(message);
+  error.stage = stage;
+
+  if (details) {
+    error.details = details;
+  }
+
+  return error;
+}
+
+function validateRequest(request) {
+  const mountName = getRequestValue(request, "mountName", "mount-name");
+  const parameters = getRequestValue(request, "parameters");
+  const configFile = getRequestValue(request, "configFile", "config-file");
+  const mwdiReplicaEsClient = getRequestValue(
+    request,
+    "mwdiReplicaEsClient",
+    "mwdi-replica-es-client"
+  );
+  const dataStoreEsClient = getRequestValue(
+    request,
+    "dataStoreEsClient",
+    "data-store-es-client"
+  );
+
+  if (
+    !request ||
+    typeof request !== "object" ||
+    Array.isArray(request)
+  ) {
+    throw buildProcessingError(ERRORS.INPUT_DATA_MISSING_OR_INVALID);
+  }
+
+  if (!mountName || typeof mountName !== "string" || mountName.trim() === "") {
+    throw buildProcessingError(ERRORS.INPUT_DATA_MISSING_OR_INVALID);
+  }
+
+  if (!parameters || !isPlainObject(parameters)) {
+    throw buildProcessingError(ERRORS.PARAMETERS_MISSING_OR_INVALID);
+  }
+
+  if (!configFile || !isPlainObject(configFile)) {
+    throw buildProcessingError(ERRORS.CONFIG_FILE_MISSING_OR_INVALID);
+  }
+
+  if (!mwdiReplicaEsClient || !isPlainObject(mwdiReplicaEsClient)) {
+    throw buildProcessingError(ERRORS.INPUT_DATA_MISSING_OR_INVALID);
+  }
+
+  if (!dataStoreEsClient || !isPlainObject(dataStoreEsClient)) {
+    throw buildProcessingError(ERRORS.INPUT_DATA_MISSING_OR_INVALID);
+  }
+
+  return {
+    mountName,
+    parameters,
+    configFile,
+    mwdiReplicaEsClient,
+    dataStoreEsClient
+  };
+}
+
+function buildTopLevelError(error, mountName) {
+  if (error && typeof error === "object" && error.message) {
+    const message = String(error.message);
+
+    if (
+      message === ERRORS.INPUT_DATA_MISSING_OR_INVALID ||
+      message === "mountName, parameters, configFile, mwdiReplicaEsClient and dataStoreEsClient are mandatory"
+    ) {
+      return buildProcessingError(ERRORS.INPUT_DATA_MISSING_OR_INVALID, error.stage || "p1ProcessDevice", {
+        vendorResponse: error.vendorResponse,
+        originalError: error
+      });
+    }
+
+    if (message === "mountName not provided" || message === "mountName invalid") {
+      return buildProcessingError(ERRORS.MOUNT_NAME_NOT_FOUND, error.stage || "p1ProcessDevice", {
+        vendorResponse: error.vendorResponse,
+        originalError: error
+      });
+    }
+
+    if (message.includes("parameters") || message.includes("Parameters")) {
+      return buildProcessingError(ERRORS.PARAMETERS_MISSING_OR_INVALID, error.stage || "p1ProcessDevice", {
+        vendorResponse: error.vendorResponse,
+        originalError: error
+      });
+    }
+
+    if (message.includes("configFile") || message.includes("config file")) {
+      return buildProcessingError(ERRORS.CONFIG_FILE_MISSING_OR_INVALID, error.stage || "p1ProcessDevice", {
+        vendorResponse: error.vendorResponse,
+        originalError: error
+      });
+    }
+
+    if (message.includes("rawCc") || message.includes("rawCc could not")) {
+      return buildProcessingError(ERRORS.RAW_CC_DATA_MISSING_OR_INVALID, error.stage || "p1ProcessDevice", {
+        vendorResponse: error.vendorResponse,
+        originalError: error
+      });
+    }
+
+    if (message.includes("resultCc") || message.includes("resultCc could not") || message.includes("result-cc")) {
+      return buildProcessingError(ERRORS.RESULT_CC_DATA_MISSING_OR_INVALID, error.stage || "p1ProcessDevice", {
+        vendorResponse: error.vendorResponse,
+        originalError: error
+      });
+    }
+
+    if (message.includes("output") || message.includes("format")) {
+      return buildProcessingError(ERRORS.OUTPUT_FORMAT_MISSING_OR_INVALID, error.stage || "p1ProcessDevice", {
+        vendorResponse: error.vendorResponse,
+        originalError: error
+      });
+    }
+
+    if (message.includes("Kafka") || message.includes("Producer") || message.includes("transmission")) {
+      return buildProcessingError(ERRORS.KAFKA_TRANSMISSION_FAILED, error.stage || "p1ProcessDevice", {
+        vendorResponse: error.vendorResponse,
+        originalError: error
+      });
+    }
+
+    if (message.includes("store") || message.includes("stored")) {
+      return buildProcessingError(ERRORS.STORING_RESULT_CC_FAILED, error.stage || "p1ProcessDevice", {
+        vendorResponse: error.vendorResponse,
+        originalError: error
+      });
+    }
+  }
+
+  return buildProcessingError(ERRORS.GENERAL_PROCESSING_ERROR, "p1ProcessDevice", {
+    mountName,
+    originalError: error
+  });
+}
 
 function getTargetConsumers(kafkaConsumerTypes) {
   return String(
@@ -94,29 +253,25 @@ async function queueKafkaOutputsOneByOne(request) {
  * }
  */
 async function run(request) {
+  let validation;
+
+  try {
+    validation = validateRequest(request);
+  } catch (error) {
+    throw buildTopLevelError(error, getRequestValue(request, "mountName", "mount-name"));
+  }
+
   const {
     mountName,
     parameters,
     configFile,
     mwdiReplicaEsClient,
-    dataStoreEsClient,
-    kafkaConsumerTypes
-  } = request;
+    dataStoreEsClient
+  } = validation;
+  const kafkaConsumerTypes = getRequestValue(request, "kafkaConsumerTypes", "kafka-consumer-types");
 
   //const logger = request.logger || console;
   let createResultCcResponse = null;
-
-  if (
-    !mountName ||
-    !parameters ||
-    !configFile ||
-    !mwdiReplicaEsClient ||
-    !dataStoreEsClient
-  ) {
-    throw new Error(
-      "mountName, parameters, configFile, mwdiReplicaEsClient and dataStoreEsClient are mandatory"
-    );
-  }
 
   try {
     const p1LoadRawCcParameters = findFunctionNode(parameters, "p1LoadRawCc");
@@ -332,12 +487,14 @@ async function run(request) {
       "Failed to process device"
     );
 
+    const normalizedError = buildTopLevelError(error, mountName);
+
     throw {
       mountName,
-      stage: error.stage || "p1ProcessDevice",
-      message: error.message || String(error),
+      stage: normalizedError.stage || "p1ProcessDevice",
+      message: normalizedError.message || String(error),
       retryable: error.retryable,
-      details: error.details,
+      details: normalizedError.details,
       vendorResponse: error.vendorResponse,
       originalError: error
     };

--- a/server/specificFunctions/p1StreamPmData/p1ProcessDevice/P1ProcessDevice.js
+++ b/server/specificFunctions/p1StreamPmData/p1ProcessDevice/P1ProcessDevice.js
@@ -66,7 +66,7 @@ function validateRequest(request) {
   }
 
   if (!mountName || typeof mountName !== "string" || mountName.trim() === "") {
-    throw buildProcessingError(ERRORS.INPUT_DATA_MISSING_OR_INVALID);
+    throw buildProcessingError(ERRORS.MOUNT_NAME_NOT_FOUND);
   }
 
   if (!parameters || !isPlainObject(parameters)) {
@@ -95,69 +95,70 @@ function validateRequest(request) {
 }
 
 function buildTopLevelError(error, mountName) {
+  const message = String(error?.message || error || "");
   if (error && typeof error === "object" && error.message) {
     const message = String(error.message);
 
-    if (
-      message === ERRORS.INPUT_DATA_MISSING_OR_INVALID ||
-      message === "mountName, parameters, configFile, mwdiReplicaEsClient and dataStoreEsClient are mandatory"
-    ) {
-      return buildProcessingError(ERRORS.INPUT_DATA_MISSING_OR_INVALID, error.stage || "p1ProcessDevice", {
+    if (ERRORS.knownErrors.has(message)) {
+      return buildProcessingError(message, error.stage || "p1ProcessDevice", {
         vendorResponse: error.vendorResponse,
         originalError: error
       });
     }
 
-    if (message === "mountName not provided" || message === "mountName invalid") {
-      return buildProcessingError(ERRORS.MOUNT_NAME_NOT_FOUND, error.stage || "p1ProcessDevice", {
-        vendorResponse: error.vendorResponse,
-        originalError: error
-      });
-    }
+    const normalized = message.toLowerCase();
 
-    if (message.includes("parameters") || message.includes("Parameters")) {
+    if (normalized.includes("parameter")) {
       return buildProcessingError(ERRORS.PARAMETERS_MISSING_OR_INVALID, error.stage || "p1ProcessDevice", {
         vendorResponse: error.vendorResponse,
         originalError: error
       });
     }
 
-    if (message.includes("configFile") || message.includes("config file")) {
+    if (normalized.includes("config")) {
       return buildProcessingError(ERRORS.CONFIG_FILE_MISSING_OR_INVALID, error.stage || "p1ProcessDevice", {
         vendorResponse: error.vendorResponse,
         originalError: error
       });
     }
 
-    if (message.includes("rawCc") || message.includes("rawCc could not")) {
+    if (normalized.includes("rawcc") || normalized.includes("raw cc")) {
       return buildProcessingError(ERRORS.RAW_CC_DATA_MISSING_OR_INVALID, error.stage || "p1ProcessDevice", {
         vendorResponse: error.vendorResponse,
         originalError: error
       });
     }
 
-    if (message.includes("resultCc") || message.includes("resultCc could not") || message.includes("result-cc")) {
+    if (
+      normalized.includes("resultcc") ||
+      normalized.includes("result cc") ||
+      normalized.includes("result-cc")
+    ) {
       return buildProcessingError(ERRORS.RESULT_CC_DATA_MISSING_OR_INVALID, error.stage || "p1ProcessDevice", {
         vendorResponse: error.vendorResponse,
         originalError: error
       });
     }
 
-    if (message.includes("output") || message.includes("format")) {
+    if (normalized.includes("output") || normalized.includes("format")) {
       return buildProcessingError(ERRORS.OUTPUT_FORMAT_MISSING_OR_INVALID, error.stage || "p1ProcessDevice", {
         vendorResponse: error.vendorResponse,
         originalError: error
       });
     }
 
-    if (message.includes("Kafka") || message.includes("Producer") || message.includes("transmission")) {
+    if (
+      normalized.includes("kafka") ||
+      normalized.includes("producer") ||
+      normalized.includes("transmission")
+    ) {
       return buildProcessingError(ERRORS.KAFKA_TRANSMISSION_FAILED, error.stage || "p1ProcessDevice", {
         vendorResponse: error.vendorResponse,
         originalError: error
       });
     }
 
-    if (message.includes("store") || message.includes("stored")) {
+    if (normalized.includes("storing") || normalized.includes("store")) {
       return buildProcessingError(ERRORS.STORING_RESULT_CC_FAILED, error.stage || "p1ProcessDevice", {
         vendorResponse: error.vendorResponse,
         originalError: error

--- a/server/specificFunctions/p1StreamPmData/p1ProcessDevice/P1ProcessDevice.test.js
+++ b/server/specificFunctions/p1StreamPmData/p1ProcessDevice/P1ProcessDevice.test.js
@@ -1,0 +1,124 @@
+jest.mock("./p1LoadRawCc/P1LoadRawCc", () => ({
+  run: jest.fn()
+}));
+
+jest.mock("./p1CreateResultCc/P1CreateResultCc", () => ({
+  run: jest.fn()
+}));
+
+jest.mock("../../../infra/kafka/queueKafkaOutbound", () => ({
+  run: jest.fn()
+}));
+
+jest.mock("./p1Storing/P1Storing", () => ({
+  run: jest.fn()
+}));
+
+jest.mock("../../../utils/functionTree.js", () => ({
+  findFunctionNode: jest.fn()
+}));
+
+jest.mock("./p1FormattingOutputApt/P1FormattingOutputApt", () => jest.fn());
+jest.mock("./p1FormattingOutputOnf/P1FormattingOutputOnf", () => jest.fn());
+
+const p1LoadRawCc = require("./p1LoadRawCc/P1LoadRawCc");
+const p1CreateResultCc = require("./p1CreateResultCc/P1CreateResultCc");
+const redisQueueKafkaOutbound = require("../../../infra/kafka/queueKafkaOutbound");
+const p1Storing = require("./p1Storing/P1Storing");
+const { findFunctionNode } = require("../../../utils/functionTree.js");
+const p1FormattingOutputApt = require("./p1FormattingOutputApt/P1FormattingOutputApt");
+const p1FormattingOutputOnf = require("./p1FormattingOutputOnf/P1FormattingOutputOnf");
+const { run } = require("./P1ProcessDevice");
+const ERRORS = require("./ErrorsEnum");
+
+const logger = {
+  info: jest.fn(),
+  error: jest.fn()
+};
+
+function validRequest(overrides = {}) {
+  return {
+    mountName: "device-1",
+    parameters: {
+      "sub-function": "p1LoadRawCc"
+    },
+    configFile: { contents: "config" },
+    mwdiReplicaEsClient: { uuid: "mwdi" },
+    dataStoreEsClient: { uuid: "data-store" },
+    kafkaConsumerTypes: "APT,ONF",
+    logger,
+    ...overrides
+  };
+}
+
+describe("P1ProcessDevice", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    findFunctionNode.mockImplementation(() => ({ some: "parameter" }));
+
+    p1LoadRawCc.run.mockResolvedValue({
+      rawCc: { "logical-termination-point": [] },
+      mountName: "device-1"
+    });
+
+    p1CreateResultCc.run.mockResolvedValue({
+      resultCc: { "batch-timestamp": "2024-01-01T00:00:00Z" },
+      interfaceMetadataList: []
+    });
+
+    p1FormattingOutputApt.mockResolvedValue({
+      "format-name": "apt-output-format",
+      "output-format": { "air-interface-list": [] }
+    });
+
+    p1FormattingOutputOnf.mockResolvedValue({
+      "format-name": "onf-output-format",
+      "output-format": { "ethernet-container-list": [] }
+    });
+
+    redisQueueKafkaOutbound.run.mockResolvedValue({});
+    p1Storing.run.mockResolvedValue({});
+  });
+
+  test("exports a run function", () => {
+    expect(typeof run).toBe("function");
+  });
+
+  test("throws Input data missing or invalid when request is incomplete", async () => {
+    await expect(run({})).rejects.toMatchObject({
+      message: ERRORS.INPUT_DATA_MISSING_OR_INVALID
+    });
+  });
+
+  test("runs the orchestration and stores results on success", async () => {
+    const result = await run(validRequest());
+
+    expect(result).toEqual({
+      resultCc: { "batch-timestamp": "2024-01-01T00:00:00Z" },
+      interfaceMetadataList: []
+    });
+
+    expect(p1LoadRawCc.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mountName: "device-1",
+        mwdiReplicaEsClient: { uuid: "mwdi" },
+        dataStoreEsClient: { uuid: "data-store" }
+      })
+    );
+
+    expect(p1CreateResultCc.run).toHaveBeenCalled();
+    expect(p1FormattingOutputApt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "result-cc": { "batch-timestamp": "2024-01-01T00:00:00Z" }
+      })
+    );
+    expect(p1FormattingOutputOnf).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "result-cc": { "batch-timestamp": "2024-01-01T00:00:00Z" }
+      })
+    );
+    expect(redisQueueKafkaOutbound.run).toHaveBeenCalledTimes(2);
+    expect(p1Storing.run).toHaveBeenCalled();
+  });
+});

--- a/server/specificFunctions/p1StreamPmData/p1ProcessDevice/p1Storing/P1Storing.js
+++ b/server/specificFunctions/p1StreamPmData/p1ProcessDevice/p1Storing/P1Storing.js
@@ -151,7 +151,7 @@ async function searchExisting(client, index, mountName, logger) {
     );
 
     //throw buildProcessingError(ERRORS.RESULT_CC_COULD_NOT_BE_STORED, error);
-      logger.error(buildProcessingError(ERRORS.RESULT_CC_COULD_NOT_BE_STORED, error).message);
+    logger.error(buildProcessingError(ERRORS.RESULT_CC_COULD_NOT_BE_STORED, error).message);
   }
 }
 
@@ -265,7 +265,10 @@ async function run(request) {
 
     existing["interface-metadata-list"] = interfaceMetadataList;
     existing.batch = Array.isArray(existing.batch) ? existing.batch : [];
-    const batchTimestamp = new Date().toJSON();
+    const batchTimestamp = getRequestValue(resultCc, "batch-timestamp", "batchTimestamp");
+    if (!batchTimestamp) {
+      throw buildProcessingError(ERRORS.BATCH_TIMESTAMP_NOT_PROVIDED);
+    }
     existing.batch.push({
       batchTimestamp,
       ...(saveResultCc ? { resultCc } : {})


### PR DESCRIPTION
## Summary

This PR contains the following changes:

### 1. Batch Timestamp Fix (p1Storing)

Previously, `batchTimestamp` was generated using the current execution time.

According to the specification, the batch timestamp should be taken from `resultCc`, representing the timestamp associated with the ControlConstruct read from the device.

**Changes**
- Retrieve `batch-timestamp` from `resultCc` instead of generating the current execution timestamp.

---

### 2. Error Handling Improvements

Implemented standardized error handling for:

- `p1ProcessDevice`
- `p1StreamPmData`

---

### 3. p1RemoveOutOfRangeTemperature

Integrated the latest agreed implementation for temperature cleanup.

Previously, when a temperature value was removed, an empty `physical-properties` object remained in the output.

**Changes**
- Remove the entire `physical-properties` object when temperature is removed due to an empty or out-of-range value.
- Verified the output no longer contains empty `physical-properties` objects after processing.